### PR TITLE
Fixes PWM

### DIFF
--- a/src/CapacitiveTouch.cpp
+++ b/src/CapacitiveTouch.cpp
@@ -102,7 +102,7 @@ void CapacitiveTouch::Init(v8::Handle<v8::Object> exports)
 void CapacitiveTouch::New(const v8::FunctionCallbackInfo<v8::Value>& args)
 {
     v8::Isolate* isolate = args.GetIsolate();
-    if (!args.Length() == 2)
+    if (args.Length() != 2)
     {
         isolate->ThrowException(v8::Exception::TypeError(v8::String::NewFromUtf8(isolate, "Wrong number of arguments")));
         return;

--- a/src/PWM.cpp
+++ b/src/PWM.cpp
@@ -10,6 +10,7 @@ v8::Persistent<v8::FunctionTemplate> PWM::constructor;
 
 PWM::PWM(std::string num) : GPIO(num), running(false)
 {
+    GPIO::open();
     GPIO::setMode(GPIO::OUT);
 }
 

--- a/src/PWM.cpp
+++ b/src/PWM.cpp
@@ -30,10 +30,14 @@ void PWM::run()
         int t = 1000 / this->freq;
         int up = this->dc * t / 100;
         int down = t - up;
-        this->write(GPIO::HIGH);
-        std::this_thread::sleep_for(std::chrono::milliseconds(up));
-        this->write(GPIO::LOW);
-        std::this_thread::sleep_for(std::chrono::milliseconds(down));
+        if(up){
+          this->write(GPIO::HIGH);
+          std::this_thread::sleep_for(std::chrono::milliseconds(up));
+        }
+        if(down){
+          this->write(GPIO::LOW);
+          std::this_thread::sleep_for(std::chrono::milliseconds(down));
+        }
     }
 }
 


### PR DESCRIPTION
For PWM output was set before exporting it, causing the pin to be configured as input. Tested on raspberrypi

Fixed a faulty argument length check in touch, haven't tested it though